### PR TITLE
Switch from bower to npm for most dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+script: bundle exec rake ci_build
 rvm:
 - 2.2.0
 env:

--- a/Rakefile
+++ b/Rakefile
@@ -32,10 +32,14 @@ task :check_for_node do
   end
 end
 
+desc "Install JavaScript components"
+task :install_js_components => :check_for_node do
+  abort unless system 'npm', 'install'
+end
+
 desc "Update JavaScript components"
 task :update_js_components => :check_for_node do
   abort unless system 'npm', 'update'
-  abort unless system 'bower', 'update'
 end
 
 LIB_LUNR_TARGET = File.join %w(lib jekyll_pages_api_search lunr.min.js)
@@ -83,6 +87,6 @@ task :build => [
 ]
 
 task :ci_build => [
-  :update_js_components,
+  :install_js_components,
   :test,
 ]

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ task :update_js_components => :check_for_node do
 end
 
 LIB_LUNR_TARGET = File.join %w(lib jekyll_pages_api_search lunr.min.js)
-LIB_LUNR_SOURCE = File.join %w(bower_components lunr.js lunr.min.js)
+LIB_LUNR_SOURCE = File.join %w(node_modules lunr lunr.min.js)
 
 file LIB_LUNR_TARGET => LIB_LUNR_SOURCE do
   FileUtils.cp LIB_LUNR_SOURCE, LIB_LUNR_TARGET

--- a/Rakefile
+++ b/Rakefile
@@ -81,3 +81,8 @@ task :build => [
   :test,
   search_bundle_gz,
 ]
+
+task :ci_build => [
+  :update_js_components,
+  :test,
+]

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var angular = require('angular/angular');
-var lunr = require('lunr.js/lunr');
-var _livesearch = require('angular-livesearch/liveSearch');
+var angular = require('angular');
+var lunr = require('lunr');
+var _livesearch = require('../../bower_components/angular-livesearch/liveSearch');
 var ngHub = angular.module('hubSearch', ['LiveSearch']);
 
 ngHub.factory('searchIndexPromise', ["$http", "$q", function($http, $q) {

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -2,7 +2,7 @@
 
 var angular = require('angular');
 var lunr = require('lunr');
-var _livesearch = require('../../bower_components/angular-livesearch/liveSearch');
+var _livesearch = require('angular-livesearch/liveSearch');
 var ngHub = angular.module('hubSearch', ['LiveSearch']);
 
 ngHub.factory('searchIndexPromise', ["$http", "$q", function($http, $q) {

--- a/bower.json
+++ b/bower.json
@@ -2,9 +2,6 @@
   "name": "jekyll_pages_api_search",
   "private": true,
   "dependencies": {
-    "jquery": "~2.1",
-    "angular": "~1.2",
-    "lunr.js": "~0.5.7",
     "angular-livesearch": "https://github.com/mauriciogentile/angular-livesearch.git"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "jekyll_pages_api_search",
-  "private": true,
-  "dependencies": {
-    "angular-livesearch": "https://github.com/mauriciogentile/angular-livesearch.git"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -1,19 +1,18 @@
 {
   "name": "jekyll_pages_api_search",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "description": "Adds lunr.js search to Jekyll sites using jekyll_pages_api",
   "homepage": "https://github.com/18F/jekyll_pages_api_search",
-  "bugs": "https://github.com/18F/jekyll_pages_api_search/issues",
+  "bugs": {
+    "url": "https://github.com/18F/jekyll_pages_api_search/issues"
+  },
   "main": "assets/js/search.js",
   "devDependencies": {
     "bower": "1.x.x",
     "browserify": "10.x.x",
-    "browserify-shim": "3.x.x",
-    "debowerify": "1.x.x",
     "uglifyify": "3.x.x"
   },
-  "scripts": {
-  },
+  "scripts": {},
   "repository": {
     "type": "git",
     "url": "git@github.com:18F/jekyll_pages_api_search.git"
@@ -24,16 +23,14 @@
     "search",
     "18F"
   ],
-  "browserify": {
-    "transform": [
-      "debowerify",
-      "browserify-shim"
-    ]
-  },
-  "browserify-shim": {
-    "bower_components/angular/angular.js": "angular"
-  },
   "author": "Mike Bland <michael.bland@gsa.gov> (https://18f.gsa.gov/)",
   "license": "CC0-1.0",
-  "readmeFilename": "README.md"
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "angular": "1.3.x",
+    "lunr": "^0.5.9",
+    "jquery": "^2.1.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "main": "assets/js/search.js",
   "devDependencies": {
-    "bower": "1.x.x",
     "browserify": "10.x.x",
+    "napa": "^1.2.0",
     "uglifyify": "3.x.x"
   },
   "scripts": {},
@@ -32,5 +32,9 @@
     "angular": "1.3.x",
     "lunr": "^0.5.9",
     "jquery": "^2.1.4"
+  },
+  "scripts": {
+    "install": "napa mauriciogentile/angular-livesearch",
+    "update": "napa mauriciogentile/angular-livesearch"
   }
 }


### PR DESCRIPTION
Prompted by @msecret to read [an article about preferring npm to bower](http://gofore.com/ohjelmistokehitys/stop-using-bower/).

This nudged me towards the convention of "rely on the npm by default" for JavaScript dependencies. This necessitated bumping the Angular version to 1.3.x, as [Angular wasn't properly browserify-able until 3.1.14](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#1314-instantaneous-browserification-2015-02-24).

The new Angular version causes a ~19K bump in minified bundle size, ~7k compressed:

```
  Before:
  133068 assets/js/search-bundle.js
   47680 assets/js/search-bundle.js.gz

  After:
  151892 assets/js/search-bundle.js
   54533 assets/js/search-bundle.js.gz
```

Bower is still used for angular-livesearch, but the debowerify transform is no longer needed, as it just calls `angular.module()` and doesn't actually export anything.

Thoughts? Worth the trouble? Leave good enough alone?

cc: @afeld 
