### PR TITLE
Support skip_index attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ and `_includes` files as you see fit:
 You can also add `@import "jekyll_pages_api_search";` to one of your [Sass
 assets](http://jekyllrb.com/docs/assets/) to use the default interface style.
 
+Add `skip_index: true` to the front matter of any documents you would like to
+exclude from the index (e.g. indexes that contain summaries of other documents).
+
 ### Customization
 
 If you prefer to craft your own versions of these tags and styles, you can

--- a/jekyll_pages_api_search.gemspec
+++ b/jekyll_pages_api_search.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'lib/jekyll_pages_api_search/lunr.min.js',
   ]
 
-  s.add_runtime_dependency 'jekyll_pages_api', '~> 0.1.3'
+  s.add_runtime_dependency 'jekyll_pages_api', '~> 0.1.4'
   s.add_runtime_dependency 'therubyracer', '~> 0.12.2'
   s.add_runtime_dependency 'sass', '~> 3.4'
   s.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jekyll_pages_api_search/search.js
+++ b/lib/jekyll_pages_api_search/search.js
@@ -12,8 +12,10 @@ var index = lunr(function() {
 var url_to_doc = {};
 
 corpus.entries.forEach(function(page) {
-  index.add(page);
-  url_to_doc[page.url] = {url: page.url, title: page.title};
+  if (page.skip_index !== true) {
+    index.add(page);
+    url_to_doc[page.url] = {url: page.url, title: page.title};
+  }
 });
 
 var result = JSON.stringify({

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -58,8 +58,17 @@ module JekyllPagesApiSearch
       end
     end
 
+    def test_skip_index_page_not_included
+      index_file = File.join(SiteBuilder::BUILD_DIR, 'search-index.json')
+
+      File.open(index_file, 'r') do |f|
+        search_index = JSON.parse f.read, :max_nesting => 200
+        assert_nil search_index['url_to_doc']['/about/']
+      end
+    end
+
     def get_tag(name)
-      Liquid::Template.tags[name].new( nil, nil, nil)
+      Liquid::Template.tags[name].new nil, nil, nil
     end
 
     def test_interface_style_present

--- a/test/test-site/about.md
+++ b/test/test-site/about.md
@@ -2,6 +2,7 @@
 layout: page
 title: About
 permalink: /about/
+skip_index: true
 ---
 
 This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)


### PR DESCRIPTION
This will help us keep docs out of the index that contain indexes or summaries of other documents, for example.

cc: @afeld 
