### PR TITLE
Bump version to v0.2.1

### DIFF
--- a/lib/jekyll_pages_api_search/version.rb
+++ b/lib/jekyll_pages_api_search/version.rb
@@ -1,5 +1,5 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 module JekyllPagesApiSearch
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
v0.2.0 had a packaging error; the search-bundle.js file was empty. I'll file an issue to update the Rakefile to catch this in the future.

cc: @afeld 
