### PR TITLE
Remove the en-dash from the search.html template

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ main_js = cxt[:package].main
 
 search_bundle = File.join 'assets', 'js', 'search-bundle.js'
 file search_bundle => main_js do
-  unless system 'browserify', '-g', 'uglifyify', main_js, :out=>search_bundle
+  unless system 'npm', 'run', 'make-bundle', :out=>search_bundle
     abort "browserify failed"
   end
 end

--- a/lib/jekyll_pages_api_search/search.html
+++ b/lib/jekyll_pages_api_search/search.html
@@ -8,7 +8,7 @@
       live-search-max-result-size="20"
       ng-model="searchText"
       ng-keydown="searchKeyDown($event)"
-      placeholder="Search – click or press '/'"
+      placeholder="Search - click or press '/'"
       aria-autocomplete="list"
       aria-activedescendant="search_result_0"
       aria-haspopup="true"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "napa": "^1.2.0",
     "uglifyify": "3.x.x"
   },
-  "scripts": {},
   "repository": {
     "type": "git",
     "url": "git@github.com:18F/jekyll_pages_api_search.git"
@@ -35,6 +34,7 @@
   },
   "scripts": {
     "install": "napa mauriciogentile/angular-livesearch",
-    "update": "napa mauriciogentile/angular-livesearch"
+    "update": "napa mauriciogentile/angular-livesearch",
+    "make-bundle": "browserify -g uglifyify assets/js/search.js"
   }
 }

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -70,7 +70,7 @@ module JekyllPagesApiSearch
     end
 
     def get_tag(name)
-      Liquid::Template.tags[name].new nil, nil, nil
+      Liquid::Template.tags[name].parse(nil, nil, nil, {})
     end
 
     def test_interface_style_present


### PR DESCRIPTION
This was causing conflicts on Windows, FreeBSD, and some Linux platforms that
looked like:

```
Configuration file: /usr/home/msb/src/unit-testing-node/_config.yml
            Source: /usr/home/msb/src/unit-testing-node
       Destination: /usr/home/msb/src/unit-testing-node/_site
 Incremental build: enabled
      Generating...
  Liquid Exception: incompatible character encodings: US-ASCII and UTF-8 in _layouts/default.html
/home/msb/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/liquid-3.0.6/lib/liquid/block.rb:147:in `join': incompatible character encodings: US-ASCII and UTF-8 (Encoding::CompatibilityError)
        from /home/msb/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/liquid-3.0.6/lib/liquid/block.rb:147:in `render_all'
```

Also includes an improved `browserify` command and fixes a couple of test breakages.

cc: @jcscottiii @afeld @andrewmaier 
