### PR TITLE
Fix v0.3.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'v8'
+require 'zlib'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
@@ -65,13 +66,8 @@ end
 
 search_bundle_gz = "#{search_bundle}.gz"
 file search_bundle_gz => search_bundle do
-  unless program_exists? 'gzip'
-    puts "Cannot determine if the gzip program exists on the system; " +
-      "skipping compression."
-    return
-  end
-  unless system 'gzip', '--best', '-c', search_bundle, :out=>search_bundle_gz
-    abort "compression failed for: #{search_bundle}"
+  ::Zlib::GzipWriter.open(search_bundle_gz, ::Zlib::BEST_COMPRESSION) do |gz|
+    gz.write(File.read(search_bundle))
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -85,6 +85,10 @@ task :build_js => [ :check_for_node ].concat(ARTIFACTS) do
   end
 end
 
+task :clean do
+  [search_bundle, search_bundle_gz].each { |f| File.unlink(f) }
+end
+
 task :test => [:build_js]
 task :build => [:test]
 task :ci_build => [:install_js_components, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ main_js = cxt[:package].main
 
 search_bundle = File.join 'assets', 'js', 'search-bundle.js'
 file search_bundle => main_js do
-  unless system 'npm', 'run', 'make-bundle', :out=>search_bundle
+  unless system 'npm', 'run', 'make-bundle'
     abort "browserify failed"
   end
 end

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -85,9 +85,9 @@ ngHub.controller('SearchController', ["$scope", "$q", "searchUi", "pagesSearch",
     }
   };
 
-  $scope.searchCallback = function(params) {
+  $scope.searchCallback = function(query) {
     var defer = $q.defer();
-    var results = pagesSearch(params.query);
+    var results = pagesSearch(query);
     defer.resolve(results);
     return defer.promise;
   };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
     "jquery": "^2.1.4"
   },
   "scripts": {
-    "install": "napa mauriciogentile/angular-livesearch#a81b8484d8f0b6abeb20dd6478444eb536dbc7ff",
+    "postinstall": "napa",
     "make-bundle": "browserify -g uglifyify assets/js/search.js -o assets/js/search-bundle.js"
+  },
+  "napa": {
+    "angular-livesearch": "mauriciogentile/angular-livesearch#a81b8484d8f0b6abeb20dd6478444eb536dbc7ff"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "jquery": "^2.1.4"
   },
   "scripts": {
-    "install": "napa mauriciogentile/angular-livesearch",
-    "update": "napa mauriciogentile/angular-livesearch",
+    "install": "napa mauriciogentile/angular-livesearch#a81b8484d8f0b6abeb20dd6478444eb536dbc7ff",
     "make-bundle": "browserify -g uglifyify assets/js/search.js -o assets/js/search-bundle.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "scripts": {
     "install": "napa mauriciogentile/angular-livesearch",
     "update": "napa mauriciogentile/angular-livesearch",
-    "make-bundle": "browserify -g uglifyify assets/js/search.js"
+    "make-bundle": "browserify -g uglifyify assets/js/search.js -o assets/js/search-bundle.js"
   }
 }


### PR DESCRIPTION
#12 and, subsequently, v0.3.1 fixed the "incompatible character encoding" problem on some platforms, but the search widget stopped working. The first problem was that I added the `make-bundle` npm script, and capturing the standard output from that script into `assets/js/search-bundle.js` also captured the info preamble from the npm command. This PR fixes that problem by capturing the output directly from `browserify` by giving it `-o assets/js/search-bundle.js` arguments.

After fixing that, the widget still didn't work because I also updated angular-livesearch, which wasn't locked to a specific version, and that update contained a breaking change to the API of the widget's callback.

This PR rectifies that problem by updating `assets/js/search.js` to use the new API and locking angular-livesearch to a specific commit.

This PR also adds an in-process `gzip` for `assets/js/search-bundle.js.gz` since it's more portable, and a `rake clean` target.

Verified locally that everything works as expected now.

cc: @jcscottiii @afeld @andrewmaier 
