### PR TITLE
Don't add baseurl to search_endpoint permalink

### DIFF
--- a/lib/jekyll_pages_api_search/search_page.rb
+++ b/lib/jekyll_pages_api_search/search_page.rb
@@ -22,9 +22,7 @@ module JekyllPagesApiSearch
     private
 
     def endpoint(site_config, search_config)
-      baseurl = "#{site_config['baseurl'] || ''}"
-      search_endpoint = search_config['endpoint'] || DEFAULT_ENDPOINT
-      "/#{baseurl}/#{search_endpoint}/".gsub(/\/+/, '/')
+      "/#{search_config['endpoint'] || DEFAULT_ENDPOINT}/".gsub(/\/+/, '/')
     end
   end
 end


### PR DESCRIPTION
Jekyll will add baseurl to permalinks, so we don't have to. (Gah, why didn't I test that?)

cc: @andrewmaier @mtorres253 
