### PR TITLE
Make widget placeholder text configurable

### DIFF
--- a/lib/jekyll_pages_api_search/config.rb
+++ b/lib/jekyll_pages_api_search/config.rb
@@ -1,5 +1,10 @@
 module JekyllPagesApiSearch
   class Config
+    def self.get(site, value)
+      search_config = site.config['jekyll_pages_api_search']
+      search_config[value] unless search_config.nil?
+    end
+
     def self.skip_index?(site)
       search_config = site.config['jekyll_pages_api_search']
       return true if search_config.nil?

--- a/lib/jekyll_pages_api_search/search.html
+++ b/lib/jekyll_pages_api_search/search.html
@@ -3,7 +3,7 @@
     <div class="field">
       <label>
         <input type="search" id="search-input" name="q"
-         placeholder="Search - click or press '/'">
+         placeholder="{{ placeholder }}">
       </label>
     </div>
   </form>

--- a/lib/jekyll_pages_api_search/tags.rb
+++ b/lib/jekyll_pages_api_search/tags.rb
@@ -1,5 +1,6 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
+require_relative './config'
 require 'liquid'
 
 module JekyllPagesApiSearch
@@ -11,10 +12,13 @@ module JekyllPagesApiSearch
 
     def render(context)
       site = context.registers[:site]
+      placeholder = Config.get(site, 'placeholder') ||
+        'Search - click or press \'/\''
       baseurl = site.config['baseurl'] || ''
       search_endpoint = site.config['search_endpoint'] || 'search/'
       search_endpoint = "/#{baseurl}/#{search_endpoint}/".gsub('//', '/')
-      TEMPLATE.render('search_endpoint' => search_endpoint)
+      TEMPLATE.render('search_endpoint' => search_endpoint,
+        'placeholder' => placeholder)
     end
   end
 


### PR DESCRIPTION
Closes #20. Users can now specify the text as the `placeholder` property of the `jekyll_pages_api_search` configuration object in `_config.yml`.

@nicoleslaw @andrewmaier @mtorres253 @ertzeid @catherinedevlin 
