### PR TITLE
Update search.html

### DIFF
--- a/lib/jekyll_pages_api_search/sass/jekyll_pages_api_search.scss
+++ b/lib/jekyll_pages_api_search/sass/jekyll_pages_api_search.scss
@@ -38,8 +38,8 @@
   border-color: #bbb;
 }
 
-.sr-only
-.search-interface span.label-text { //for screen readers
+.sr-only,
+.search-interface span.label-text {
   position: absolute;
   overflow: hidden;
   width:1px;

--- a/lib/jekyll_pages_api_search/sass/jekyll_pages_api_search.scss
+++ b/lib/jekyll_pages_api_search/sass/jekyll_pages_api_search.scss
@@ -1,11 +1,11 @@
 @media screen and (min-width: 45em) {
-  div.search-interface{
+  .search-interface{
       width: 30%;
       float: right;
   }
 }
 
-div.search-interface input {
+.search-interface input {
   display: block;
   -webkit-box-sizing: border-box;
   width: 100%;
@@ -18,7 +18,7 @@ div.search-interface input {
   background-size: 16px;
 }
 
-div.search-interface form button {
+.search-interface button {
   position: absolute;
   left: -9999em;
   bottom: 3px;
@@ -32,13 +32,14 @@ div.search-interface form button {
   padding: 4px 12px;
 }
 
-div.search-interface form button:hover {
+.search-interface button:hover {
   background-color: #eee;
   color: #111;
   border-color: #bbb;
 }
 
-.sr-only { //for screen readers
+.sr-only
+.search-interface span.label-text { //for screen readers
   position: absolute;
   overflow: hidden;
   width:1px;

--- a/lib/jekyll_pages_api_search/search.html
+++ b/lib/jekyll_pages_api_search/search.html
@@ -1,11 +1,10 @@
-<div class="search-interface">
-  <form action="{{ search_endpoint }}">
-    <div class="field">
-      <label>
-        <input type="search" id="search-input" name="q"
-         placeholder="{{ placeholder }}">
-      </label>
-    </div>
-    <button type="submit">Search</button>
-  </form>
-</div>
+<form action="{{ search_endpoint }}" class="search-interface">
+  <div class="field">
+    <label>
+      <span class="label-text">Search</span>
+      <input type="search" id="search-input" name="q"
+       placeholder="{{ placeholder }}">
+    </label>
+  </div>
+  <button type="submit">Search</button>
+</form>

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -80,7 +80,7 @@ module JekyllPagesApiSearch
       css_path = File.join(SiteBuilder::BUILD_DIR, 'css', 'main.css')
       assert(File.exist?(css_path), "css/main.css does not exist")
       File.open(css_path, 'r') do |f|
-        assert_includes(f.read, 'div.search-interface',
+        assert_includes(f.read, '.search-interface',
           'generated files do not contain interface style code')
       end
     end


### PR DESCRIPTION
Add text to the `label` element for screen readers. Also removing the extraneous `div` surrounding the `form`.

See: http://www.456bereastreet.com/archive/201204/the_html5_placeholder_attribute_is_not_a_substitute_for_the_label_element/

cc @mbland 
